### PR TITLE
feat: Use Rust's Generic Associated Types for item lifetime management

### DIFF
--- a/bindings/python/src/item_wrapper.rs
+++ b/bindings/python/src/item_wrapper.rs
@@ -53,9 +53,12 @@ impl std::cmp::PartialOrd for ItemWrapper {
 }
 
 impl base_openchecks::Item for ItemWrapper {
-    type Value = PyResult<PyObject>;
+    type Value<'a>
+        = PyResult<PyObject>
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         Python::with_gil(|py| self.item.call_method0(py, intern!(py, "value")))
     }
 }

--- a/bindings/python/tests/test_discovery_registry.py
+++ b/bindings/python/tests/test_discovery_registry.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
     pass
 
 
-class TestCheck(openchecks.BaseCheck):
+class Check(openchecks.BaseCheck):
     def check(self) -> openchecks.CheckResult[int]:
         return openchecks.CheckResult.passed("test")
 
@@ -22,7 +22,7 @@ class TestCheck(openchecks.BaseCheck):
         return "description"
 
 
-class AsyncTestCheck(openchecks.AsyncBaseCheck):
+class AsyncCheck(openchecks.AsyncBaseCheck):
     async def async_check(self) -> openchecks.CheckResult[int]:
         return openchecks.CheckResult.passed("test")
 
@@ -35,7 +35,7 @@ class AsyncTestCheck(openchecks.AsyncBaseCheck):
 
 def test_discovery_registry_register_and_gather_success() -> None:
     registry = openchecks.DiscoveryRegistry()
-    registry.register(lambda _: True, lambda _: [TestCheck()])
+    registry.register(lambda _: True, lambda _: [Check()])
     result = registry.gather(None)
 
     assert result
@@ -51,7 +51,7 @@ def test_discovery_registry_gather_empty_plugins_success() -> None:
 
 def test_discovery_registry_query_context_gather_return_some_success() -> None:
     registry = openchecks.DiscoveryRegistry()
-    registry.register(lambda _: True, lambda _: [TestCheck()])
+    registry.register(lambda _: True, lambda _: [Check()])
     result = registry.gather(None)
 
     assert result is not None
@@ -59,7 +59,7 @@ def test_discovery_registry_query_context_gather_return_some_success() -> None:
 
 def test_discovery_registry_query_context_gather_return_none_success() -> None:
     registry = openchecks.DiscoveryRegistry()
-    registry.register(lambda _: False, lambda _: [TestCheck()])
+    registry.register(lambda _: False, lambda _: [Check()])
     result = registry.gather(None)
 
     assert result is None
@@ -68,7 +68,7 @@ def test_discovery_registry_query_context_gather_return_none_success() -> None:
 @pytest.mark.asyncio
 async def test_discovery_registry_register_and_gather_async_success() -> None:
     registry = openchecks.DiscoveryRegistry()
-    registry.register_async(lambda _: True, lambda _: [AsyncTestCheck()])
+    registry.register_async(lambda _: True, lambda _: [AsyncCheck()])
     result = registry.gather_async(None)
 
     assert result
@@ -88,7 +88,7 @@ async def test_discovery_registry_query_context_gather_async_return_some_success
     None
 ):
     registry = openchecks.DiscoveryRegistry()
-    registry.register_async(lambda _: True, lambda _: [AsyncTestCheck()])
+    registry.register_async(lambda _: True, lambda _: [AsyncCheck()])
     result = registry.gather_async(None)
 
     assert result
@@ -99,7 +99,7 @@ async def test_discovery_registry_query_context_gather_async_return_none_success
     None
 ):
     registry = openchecks.DiscoveryRegistry()
-    registry.register_async(lambda _: False, lambda _: [AsyncTestCheck()])
+    registry.register_async(lambda _: False, lambda _: [AsyncCheck()])
     result = registry.gather_async(None)
 
     assert result is None

--- a/examples/async_auto_fix.rs
+++ b/examples/async_auto_fix.rs
@@ -12,9 +12,12 @@ impl std::fmt::Display for NumberItem {
 // The item container lets a type that is normally not debuggable, displayable,
 // or sortable to be. This is only really useful for graphical user interfaces.
 impl openchecks::Item for NumberItem {
-    type Value = i32;
+    type Value<'a>
+        = i32
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.number
     }
 }

--- a/examples/async_check.rs
+++ b/examples/async_check.rs
@@ -12,9 +12,12 @@ impl std::fmt::Display for NumberItem {
 // The item container lets a type that is normally not debuggable, displayable,
 // or sortable to be. This is only really useful for graphical user interfaces.
 impl openchecks::Item for NumberItem {
-    type Value = i32;
+    type Value<'a>
+        = i32
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.number
     }
 }

--- a/examples/auto_fix.rs
+++ b/examples/auto_fix.rs
@@ -12,9 +12,12 @@ impl std::fmt::Display for NumberItem {
 // The item container lets a type that is normally not debuggable, displayable,
 // or sortable to be. This is only really useful for graphical user interfaces.
 impl openchecks::Item for NumberItem {
-    type Value = i32;
+    type Value<'a>
+        = i32
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.number
     }
 }

--- a/examples/check.rs
+++ b/examples/check.rs
@@ -12,9 +12,12 @@ impl std::fmt::Display for NumberItem {
 // The item container lets a type that is normally not debuggable, displayable,
 // or sortable to be. This is only really useful for graphical user interfaces.
 impl openchecks::Item for NumberItem {
-    type Value = i32;
+    type Value<'a>
+        = i32
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.number
     }
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -78,9 +78,12 @@ pub trait CheckMetadata {
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }
@@ -138,9 +141,12 @@ pub trait CheckMetadata {
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }
@@ -242,9 +248,12 @@ pub trait Check: CheckMetadata {
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }
@@ -306,9 +315,12 @@ pub trait Check: CheckMetadata {
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }

--- a/src/discovery_registry.rs
+++ b/src/discovery_registry.rs
@@ -26,9 +26,12 @@ use crate::{AsyncCheck, Check};
 /// # }
 /// #
 /// # impl Item for MyItem {
-/// #     type Value = u8;
+/// #     type Value<'a>
+/// #             = u8
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.value
 /// #     }
 /// # }

--- a/src/item.rs
+++ b/src/item.rs
@@ -47,10 +47,13 @@
 ///     }
 /// }
 ///
-/// impl<'a> Item for &'a SceneItem {
-///     type Value = &'a SceneNode;
+/// impl Item for SceneItem {
+///     type Value<'a>
+///             = &'a SceneNode
+///         where
+///             Self: 'a;
 ///
-///     fn value(&self) -> Self::Value {
+///     fn value(&self) -> Self::Value<'_> {
 ///         &self.scene_node
 ///     }
 /// }
@@ -66,10 +69,12 @@ pub trait Item:
     std::cmp::PartialEq + std::cmp::PartialOrd + std::fmt::Display + std::fmt::Debug
 {
     /// The value that is wrapped.
-    type Value;
+    type Value<'a>
+    where
+        Self: 'a;
 
     /// The wrapped value.
-    fn value(&self) -> Self::Value;
+    fn value(&self) -> Self::Value<'_>;
 
     /// A type hint can be used to add a hint to a system that the given type
     /// represents something else. For example, the value could be a string, but

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -25,9 +25,12 @@
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }
@@ -119,9 +122,12 @@ pub async fn async_run<
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }
@@ -248,9 +254,12 @@ pub async fn async_auto_fix<
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }
@@ -338,9 +347,12 @@ pub fn run<
 /// # }
 /// #
 /// # impl Item for IntItem {
-/// #     type Value = i32;
+/// #     type Value<'a>
+/// #             = i32
+/// #         where
+/// #             Self: 'a;
 /// #
-/// #     fn value(&self) -> Self::Value {
+/// #     fn value(&self) -> Self::Value<'_> {
 /// #         self.0
 /// #     }
 /// # }

--- a/tests/test_check.rs
+++ b/tests/test_check.rs
@@ -14,9 +14,12 @@ impl std::fmt::Display for TestItem {
 }
 
 impl Item for TestItem {
-    type Value = u8;
+    type Value<'a>
+        = u8
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.value
     }
 }

--- a/tests/test_discovery_registry.rs
+++ b/tests/test_discovery_registry.rs
@@ -16,9 +16,12 @@ impl std::fmt::Display for TestItem {
 }
 
 impl Item for TestItem {
-    type Value = u8;
+    type Value<'a>
+        = u8
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.value
     }
 }

--- a/tests/test_item.rs
+++ b/tests/test_item.rs
@@ -12,8 +12,12 @@ impl std::fmt::Display for TestItem {
 }
 
 impl Item for TestItem {
-    type Value = ();
-    fn value(&self) -> Self::Value {
+    type Value<'a>
+        = ()
+    where
+        Self: 'a;
+
+    fn value(&self) -> Self::Value<'_> {
         self.value
     }
 }

--- a/tests/test_result.rs
+++ b/tests/test_result.rs
@@ -12,9 +12,12 @@ impl std::fmt::Display for TestItem {
 }
 
 impl Item for TestItem {
-    type Value = u8;
+    type Value<'a>
+        = u8
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.value
     }
 }

--- a/tests/test_runner.rs
+++ b/tests/test_runner.rs
@@ -17,9 +17,12 @@ impl std::fmt::Display for TestItem {
 }
 
 impl Item for TestItem {
-    type Value = u8;
+    type Value<'a>
+        = u8
+    where
+        Self: 'a;
 
-    fn value(&self) -> Self::Value {
+    fn value(&self) -> Self::Value<'_> {
         self.value
     }
 }


### PR DESCRIPTION
Signed-off-by: Scott Wilson <scott@propersquid.com>